### PR TITLE
Fix jekyll serve error on ruby 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@
 
 source "https://rubygems.org"
 gemspec
+
+gem "webrick", "~> 1.8"


### PR DESCRIPTION
This will fix `jekyll serve` emits error on ruby 3 or higher versions and latest jekyll/jekyll docker container.

The reason why it failed is that on Ruby 3 or higher, Ruby does not ship with necessary `webrick` dependency by default.

https://github.com/jekyll/jekyll/issues/9110

Since `webrick` gem is added in Gemfile, jekyll will require the dependencies and install them automatically.